### PR TITLE
Docker container can't be set to network_mode:host

### DIFF
--- a/ansible/roles/plex/tasks/main.yml
+++ b/ansible/roles/plex/tasks/main.yml
@@ -65,7 +65,7 @@
       VIRTUAL_PORT: 32400
       LETSENCRYPT_HOST: "plex.{{domain}}"
       LETSENCRYPT_EMAIL: "{{email}}"
-    network_mode: "host"
+#    network_mode: "host"
     volumes:
       - "/tmp:/tmp"
       - "/opt/appdata/plex/database:/config"


### PR DESCRIPTION
Docker container can't be set to network_mode: "host" AND networks.  Flags an error. 
-Publish ports takes care of it.