### PR TITLE
Install basic system health monitoring tools

### DIFF
--- a/scripts/baseinstall/main.sh
+++ b/scripts/baseinstall/main.sh
@@ -36,6 +36,10 @@ yes | apt-get update 1>/dev/null 2>&1
 echo "15" | dialog --gauge "Installing: Software Properties Common" 7 50 0
 yes | apt-get install software-properties-common 1>/dev/null 2>&1
 
+echo "17" | dialog --gauge "Enabling System Health Monitoring" 7 50 0
+yes | apt-get install sysstat nmon 1>/dev/null 2>&1
+sed -i 's/false/true/g' /etc/default/sysstat 1>/dev/null 2>&1
+
 echo "20" | dialog --gauge "Installing: Ansible Playbook" 7 50 0
 yes | apt-add-repository ppa:ansible/ansible 1>/dev/null 2>&1
 apt-get update -y 1>/dev/null 2>&1


### PR DESCRIPTION
Add a section to install sysstat and nmon to enable system health and performance monitoring utilities. Sysstat adds the sar command to the system and nmon is an interactive monitor. Sysstat also requires one change to /etc/default/sysstat:

ENABLED="false"

must be changed to

ENABLED="true"

Without this change, the sar command does not work. The sed command makes the required change in the file to enable system statistics to be collected.