### PR TITLE
Resolve Incorrect Rutorrents Mapping

### DIFF
--- a/ansible/roles/lidarr/tasks/main.yml
+++ b/ansible/roles/lidarr/tasks/main.yml
@@ -25,7 +25,7 @@
       - /mnt/unionfs:/unionfs
       - /mnt/sab/complete:/complete
       - /mnt/nzbget/completed:/completed
-      - /mnt/rutorrents/downloads:/downloads
+      - /mnt/rutorrents:/downloads
       - /mnt/deluge/downloaded:/downloaded
       - /mnt/torrentvpn/downloaded:/data/completed
       - /etc/localtime:/etc/localtime:ro

--- a/ansible/roles/radarr/tasks/main.yml
+++ b/ansible/roles/radarr/tasks/main.yml
@@ -25,7 +25,7 @@
       - /mnt/torrentvpn/downloaded:/data/completed
       - /mnt/sab/complete:/complete
       - /mnt/nzbget/completed:/completed
-      - /mnt/rutorrents/downloads:/downloads
+      - /mnt/rutorrents:/downloads
       - /mnt/deluge/downloaded:/downloaded
       - /etc/localtime:/etc/localtime:ro
     restart_policy: always

--- a/ansible/roles/sonarr/tasks/main.yml
+++ b/ansible/roles/sonarr/tasks/main.yml
@@ -26,7 +26,7 @@
       - /mnt/nzbget/completed:/completed
       - /mnt/deluge/downloaded:/downloaded
       - /mnt/torrentvpn/downloaded:/data/completed
-      - /mnt/rutorrents/downloads/incoming:/downloads
+      - /mnt/rutorrents:/downloads
       - /etc/localtime:/etc/localtime:ro
     restart_policy: always
     state: started


### PR DESCRIPTION
Resolving issue with sonarr/radarr/lidarr mapping the downloads location of rutorrent incorrectly. This causes issues when they try to import files as they aren't looking at the correct directory.
Same issue was discussed here https://www.reddit.com/r/radarr/comments/5qvjg9/import_failed_path_does_not_exist_or_is_not/