### PR TITLE
Removed --no-traverse option

### DIFF
--- a/ansible/roles/clean-encrypt/templates/config.js2
+++ b/ansible/roles/clean-encrypt/templates/config.js2
@@ -28,7 +28,6 @@
             "rclone_extras": {
                 "--checkers": 16,
                 "--drive-chunk-size": "64M",
-                "--no-traverse": null,
                 "--stats": "60s",
                 "--transfers": 8,
                 "--verbose": 1

--- a/ansible/roles/clean/templates/config.js2
+++ b/ansible/roles/clean/templates/config.js2
@@ -28,7 +28,6 @@
             "rclone_extras": {
                 "--checkers": 16,
                 "--drive-chunk-size": "64M",
-                "--no-traverse": null,
                 "--stats": "60s",
                 "--transfers": 8,
                 "--verbose": 1

--- a/ansible/roles/rclone_cache_en/templates/move-en_script.js2
+++ b/ansible/roles/rclone_cache_en/templates/move-en_script.js2
@@ -3,7 +3,7 @@ sleep 30
 while true
 do
 ## Sync, Sleep 8 Minutes, Repeat. BWLIMIT Prevents Google 750GB Google Upload Ban
-rclone move --bwlimit 10M --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --no-traverse --checkers=16 --max-size 99G --log-level INFO --stats 5s /mnt/move gcrypt:/
+rclone move --bwlimit 10M --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --max-size 99G --log-level INFO --stats 5s /mnt/move gcrypt:/
 sleep 480
 # Remove empty directories (MrWednesday)
 find "/mnt/move/" -mindepth 2 -type d -empty -delete

--- a/ansible/roles/rclone_en/templates/move-en_script.js2
+++ b/ansible/roles/rclone_en/templates/move-en_script.js2
@@ -3,7 +3,7 @@ sleep 30
 while true
 do
 ## Sync, Sleep 8 Minutes, Repeat. BWLIMIT Prevents Google 750GB Google Upload Ban
-rclone move --bwlimit 10M --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --no-traverse --checkers=16 --max-size 99G --log-level INFO --stats 5s /mnt/move gcrypt:/
+rclone move --bwlimit 10M --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --max-size 99G --log-level INFO --stats 5s /mnt/move gcrypt:/
 sleep 480
 # Remove empty directories (MrWednesday)
 find "/mnt/move/" -mindepth 2 -type d -empty -delete

--- a/ansible/roles/rclone_un/templates/move_script.js2
+++ b/ansible/roles/rclone_un/templates/move_script.js2
@@ -3,7 +3,7 @@ sleep 30
 while true
 do
 ## Sync, Sleep 8 Minutes, Repeat. BWLIMIT Prevents Google 750GB Google Upload Ban
-rclone move --bwlimit 10M --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --no-traverse --checkers=16 --max-size 99G --log-level INFO --stats 5s /mnt/move gdrive:/
+rclone move --bwlimit 10M --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --max-size 99G --log-level INFO --stats 5s /mnt/move gdrive:/
 sleep 480
 # Remove empty directories (MrWednesday)
 find "/mnt/move/" -mindepth 2 -type d -empty -delete

--- a/scripts/docker-no/rclone-en.sh
+++ b/scripts/docker-no/rclone-en.sh
@@ -164,7 +164,7 @@ sleep 30
 while true
 do
 ## Sync, Sleep 10 Minutes, Repeat. BWLIMIT Prevents Google 750GB Google Upload Ban
-rclone move --bwlimit 10M --tpslimit 6 --exclude='**.partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --no-traverse --checkers=16 --max-size 99G --log-level INFO --stats 15s /mnt/move gcrypt:/
+rclone move --bwlimit 10M --tpslimit 6 --exclude='**.partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --max-size 99G --log-level INFO --stats 15s /mnt/move gcrypt:/
 # Remove empty directories (MrWednesday)
 find "/mnt/move/" -mindepth 2 -type d -empty -delete
 sleep 480

--- a/scripts/docker-no/rclone-en2.sh
+++ b/scripts/docker-no/rclone-en2.sh
@@ -167,7 +167,7 @@ sleep 30
 while true
 do
 ## Sync, Sleep 10 Minutes, Repeat. BWLIMIT Prevents Google 750GB Google Upload Ban
-rclone move --bwlimit 10M --tpslimit 6 --exclude='**.partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --no-traverse --checkers=16 --max-size 99G --log-level INFO --stats 5s /mnt/move gcrypt:/
+rclone move --bwlimit 10M --tpslimit 6 --exclude='**.partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --max-size 99G --log-level INFO --stats 5s /mnt/move gcrypt:/
 sleep 480
 # Remove empty directories (MrWednesday)
 find "/mnt/move/" -mindepth 2 -type d -empty -delete

--- a/scripts/docker-no/supertransfer.sh
+++ b/scripts/docker-no/supertransfer.sh
@@ -88,7 +88,7 @@ rclone_sync() {
 	        *) drive_chunk_size="16M" ;;
 	esac
 
-	rclone move --tpslimit 6 --no-traverse --checkers=16 \
+	rclone move --tpslimit 6 --checkers=16 \
 		--log-file=/opt/appdata/plexguide/rclone \
 		--log-level INFO --stats 5s \
 		--exclude="**partial~" --exclude="**_HIDDEN~" \

--- a/scripts/docker-no/transfer.sh
+++ b/scripts/docker-no/transfer.sh
@@ -67,7 +67,7 @@ do
 		echo "$data" > /opt/appdata/plexguide/data
 		echo "finish flag"
 		rm -r /opt/appdata/plexguide/rclone
-		rclone move --delete-empty-src-dirs --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --no-traverse --checkers=16 --log-file=/opt/appdata/plexguide/rclone --max-size 99G --log-level INFO --stats 5s /mnt/move gdrive:/
+		rclone move --delete-empty-src-dirs --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --log-file=/opt/appdata/plexguide/rclone --max-size 99G --log-level INFO --stats 5s /mnt/move gdrive:/
 		echo "sleeping for 120 seconds"
 		sleep 120
 		echo "resuming"


### PR DESCRIPTION
This is no longer needed, as of rclone 1.40 it does nothing except put a message saying it has been removed in the log.