### PR TITLE
Multi-port rtorrentvpn main.yml

### DIFF
--- a/ansible/roles/rtorrentvpn/tasks/main.yml
+++ b/ansible/roles/rtorrentvpn/tasks/main.yml
@@ -141,5 +141,9 @@
     labels:
       traefik.enable: "true"
       traefik.frontend.redirect.entryPoint: "https"
-      traefik.frontend.rule: "Host:rtorrentvpn.## {{domain.stdout}"
-      traefik.port: "3000"
+#      traefik.frontend.rule: "Host:rtorrentvpn.{{domain.stdout}}"
+#      traefik.port: "3000"
+      traefik.flood.port: "3000"
+      traefik.rutorrent.port: "9080"
+      traefik.flood.frontend.rule: "Host:flood.{{domain.stdout}}"
+      traefik.rutorrent.frontend.rule: "Host:rutorrent.{{domain.stdout}}"


### PR DESCRIPTION
Traefik 1.6 adds segments to support containers with multiple exposed ports.  See https://docs.traefik.io/v1.6/configuration/backends/docker/#on-containers-with-multiple-ports-segment-labels.  
The above config uses the new functionality to allow the user to access both the rutorrent web interface and the flood web interface by using different hostnames.