### PR TITLE
Add wait period to prevent timeout error

### DIFF
--- a/ansible/roles/traefik2/templates/traefik.toml
+++ b/ansible/roles/traefik2/templates/traefik.toml
@@ -53,6 +53,7 @@ entryPoint = "https"
 
 [[acme.domains]]
   main = "*.yourdomain.com"
+  delayBeforeCheck = 30
 
 [docker]
 endpoint = "unix:///var/run/docker.sock"


### PR DESCRIPTION
In some cases, the DNS provider might take a few seconds to add the TXT record, but by the time this is processed, the check has already gotten a SERVFAIL from the DNS, and marked the challenge as a failure.