### PR TITLE
move folder deletion

### DIFF
--- a/scripts/docker-no/supertransfer.sh
+++ b/scripts/docker-no/supertransfer.sh
@@ -97,7 +97,6 @@ rclone_sync() {
 		--drive-upload-cutoff=$drive_upload_cutoff \
 		--drive-chunk-size=$drive_chunk_size \
 		--max-size=$max_size \
-		--delete-empty-src-dirs \
 		$local_dir $1:$remote_dir # function input = gdrive remote name
 	}
 

--- a/scripts/docker-no/transfer.sh
+++ b/scripts/docker-no/transfer.sh
@@ -67,7 +67,7 @@ do
 		echo "$data" > /opt/appdata/plexguide/data
 		echo "finish flag"
 		rm -r /opt/appdata/plexguide/rclone
-		rclone move --delete-empty-src-dirs --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --log-file=/opt/appdata/plexguide/rclone --max-size 99G --log-level INFO --stats 5s /mnt/move gdrive:/
+		rclone move --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --log-file=/opt/appdata/plexguide/rclone --max-size 99G --log-level INFO --stats 5s /mnt/move gdrive:/
 		echo "sleeping for 120 seconds"
 		sleep 120
 		echo "resuming"


### PR DESCRIPTION
Removes rclone move flags that caused it to delete folders inside the "/mnt/move" folder