### PR TITLE
Fixed a typo

### DIFF
--- a/ansible/roles/heimdall/tasks/main.yml
+++ b/ansible/roles/heimdall/tasks/main.yml
@@ -47,5 +47,5 @@
     labels:
       traefik.enable: "true"
       traefik.frontend.redirect.entryPoint: "https"
-      traefik.frontend.rule: "Host:heimdall.{domain.stdout}}"
+      traefik.frontend.rule: "Host:heimdall.{{domain.stdout}}"
       traefik.port: "80"


### PR DESCRIPTION
Traefik now registers heimdall and makes it a sub-domain.