### PR TITLE
Add lazy librarian to the plexguide network

### DIFF
--- a/ansible/roles/lazy/tasks/main.yml
+++ b/ansible/roles/lazy/tasks/main.yml
@@ -50,6 +50,10 @@
       PGID: 1000
     restart_policy: always
     state: started
+    networks:
+      - name: plexguide
+        aliases:
+          - lazy
     labels:
       traefik.enable: "true"
       traefik.frontend.redirect.entryPoint: "https"

--- a/menus/backup-restore/restoremass.sh
+++ b/menus/backup-restore/restoremass.sh
@@ -151,7 +151,7 @@ rm -r /opt/appdata/var* 1>/dev/null 2>&1
 
 chmod 600 /opt/appdata/traefik/acme/acme.json 1>/dev/null 2>&1
 
-dialog --title "PG Restore Status" --msgbox "\nMass Application Restore Complete! You must REDPLOY each Application!" 0 0
+dialog --title "PG Restore Status" --msgbox "\nMass Application Restore Complete! You must REDEPLOY each Application!" 0 0
 clear
 
 echo "Mass Restore Complete!" > /tmp/pushover


### PR DESCRIPTION
Lazy Librarian configuration screen wasn't recognizing "deluge" as a network name.

I looked at configuration in portainer and lazy wasn't part of the plexguide network. Adding it manually allowed it to resolve network names like "deluge" when ports are closed.