### PR TITLE
Add duplicati to traefik

### DIFF
--- a/ansible/roles/duplicati/tasks/main.yml
+++ b/ansible/roles/duplicati/tasks/main.yml
@@ -150,13 +150,13 @@
       path: /opt/appdata/traefik/traefik.toml
       insertafter: EOF
       block: |
-      ################################################################
-      # File configuration backend
-      ################################################################
-      # Enable file configuration backend
-      # Optional
-      [file]
-        filename = "/etc/traefik/servers.toml"
+        ################################################################
+        # File configuration backend
+        ################################################################
+        # Enable file configuration backend
+        # Optional
+        [file]
+              filename = "/etc/traefik/servers.toml"
 
-      # Enable watch file changes
-        watch = true
+        # Enable watch file changes
+          watch = true

--- a/ansible/roles/duplicati/tasks/main.yml
+++ b/ansible/roles/duplicati/tasks/main.yml
@@ -123,3 +123,40 @@
       state: started
       enabled: yes
     tags: duplicati
+
+####################################Traefik
+
+  - name: Install servers.toml
+    template:
+      src: servers.toml
+      dest: /opt/appdata/traefik/servers.toml
+      force: yes
+      owner: 1000
+      group: 1000
+
+  - name: Register Domain
+    shell: "cat /var/plexguide/server.domain"
+    register: domain
+    ignore_errors: true
+
+  - name: Replace Domain
+    replace:
+      path: /opt/appdata/traefik/servers.toml
+      regexp: yourdomain.com
+      replace: "{{domain.stdout}}"
+
+  - name: Update traefik.toml
+    blockinfile:
+      path: /opt/appdata/traefik/traefik.toml
+      insertafter: EOF
+      block: |
+      ################################################################
+      # File configuration backend
+      ################################################################
+      # Enable file configuration backend
+      # Optional
+      [file]
+        filename = "/etc/traefik/servers.toml"
+
+      # Enable watch file changes
+        watch = true

--- a/ansible/roles/duplicati/templates/servers.toml
+++ b/ansible/roles/duplicati/templates/servers.toml
@@ -1,0 +1,13 @@
+loglevel = "ERROR"
+
+[backends]
+[backends.duplicati]
+        [backends.duplicati.servers.duplicati]
+            url = "http://yourdomain.com:8200"
+
+[frontends]
+        [frontends.domain]
+                 entryPoints = ["http", "https"]
+                 backend = "duplicati"
+        [frontends.domain.routes.domain]
+                rule = "Host:duplicati.yourdomain.com"

--- a/ansible/roles/traefik2/tasks/main.yml
+++ b/ansible/roles/traefik2/tasks/main.yml
@@ -129,6 +129,7 @@
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /etc/localtime:/etc/localtime:ro
       - /opt/appdata/traefik/traefik.toml:/etc/traefik/traefik.toml:ro
+      - /opt/appdata/traefik/servers.toml:/etc/traefik/servers.toml:ro
       - /opt/appdata/traefik/acme:/etc/traefik/acme
     restart_policy: always
     state: started


### PR DESCRIPTION
Added duplicati to traefik.
subdomain = duplicati.yourdomain.com
http and https works but no redirect yet.
Tested and working on google cloud instance with traefik2