### PR TITLE
NextCloud fix

### DIFF
--- a/ansible/roles/next/tasks/main.yml
+++ b/ansible/roles/next/tasks/main.yml
@@ -27,7 +27,7 @@
     - /opt/appdata/nextcloud/data
     - /opt/appdata/nextcloud/mariadb
 
-- name: Destory NextCloud Container
+- name: Destroy NextCloud Container
   docker_container:
     name: next
     state: absent
@@ -81,3 +81,4 @@
       traefik.frontend.redirect.entryPoint: "https"
       traefik.frontend.rule: "Host:nextcloud.{{domain.stdout}}"
       traefik.port: "443"
+      traefik.protocol: "https"

--- a/ansible/roles/traefik/templates/traefik.toml
+++ b/ansible/roles/traefik/templates/traefik.toml
@@ -29,6 +29,8 @@
 # Accepted values, in order of severity: "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "PANIC"
 # Messages at and above the selected level will be logged.
 #
+insecureskipverify = true
+
 logLevel = "WARN"
 
 defaultEntryPoints = ["http", "https"]

--- a/ansible/roles/traefik2/templates/traefik.toml
+++ b/ansible/roles/traefik2/templates/traefik.toml
@@ -28,6 +28,8 @@
 # Default: "ERROR"
 # Accepted values, in order of severity: "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "PANIC"
 
+insecureskipverify = true
+
 logLevel = "WARN"
 
 defaultEntryPoints = ["http", "https"]


### PR DESCRIPTION
Fixed a few files to make NextCloud work again out of the box.
Basically, make traefik use HTTPS to comunicate with 443 port on NextCloud container (instead of plain HTTP), and force traefik to not check the certificate of the container which is connecting to (as it is a dummy and not signed correctly).