### PR TITLE
Conditional acceptance installer

### DIFF
--- a/scripts/curlinstall.sh
+++ b/scripts/curlinstall.sh
@@ -3,7 +3,7 @@
 # [PlexGuide Curl Install]
 #
 # GitHub:   https://github.com/Admin9705/PlexGuide.com-The-Awesome-Plex-Server
-# Author:   Admin9705 - Deiteq
+# Author:   "Admin9705 - Deiteq, and YipYup"
 # URL:      https://plexguide.com
 #
 # PlexGuide Copyright (C) 2018 PlexGuide.com

--- a/scripts/curlinstall.sh
+++ b/scripts/curlinstall.sh
@@ -19,7 +19,7 @@ echo " --------------------------------------------------------------------- ";
 echo " [ ! ]          C A U T I O N!           !C U I D A D O!          [ ! ]";
 echo " --------------------------------------------------------------------- ";
 echo "";
-echo "THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED"
+echo ""THIS SOFTWARE IS PROVIDED \"AS IS\" AND ANY EXPRESSED OR IMPLIED"";
 echo "WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES"
 echo "OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED."
 echo "IN NO EVENT SHALL THE PROJECT MAINTAINERS OR PROJECT CONTRIBUTORS BE"
@@ -35,6 +35,7 @@ echo "";
 echo " Installation of this software is subject to your acceptance of"
 echo "  these terms."
 echo "";
+# read: safe shell input check. non-negated answer continues, else aborts.
 read -p "Do you accept these terms? (Y/n)" -n 1 -r
 echo    # move cursor to a new line
 echo ""
@@ -68,6 +69,8 @@ then
     echo "";
     echo "";
     echo "ABORTING per user request.";
+    echo "";
+    echo "";
     exit 1;
 else
     echo "";# leave if statement and continue.

--- a/scripts/curlinstall.sh
+++ b/scripts/curlinstall.sh
@@ -58,9 +58,6 @@ echo "  in-production server may break your environment and pre-existing setup"
 echo "  of software, programs, scripts, applications, etc."
 echo "";
 echo "";
-#  apt-get upate -y # retrive list of available updates
-#  apt-get upgrade -y" # upgrade out-of-date packages
-#  apt-get fullupgrade -y " # upgrade the OS to latest MAJOR version. ie 12.04 to 18.04. Potentially DANGEROUS for those who may understand what it implies.
 # read: safe shell input check. non-negated answer continues, else aborts.
 read -p "Would you like to proceed updating and upgrading your OS and ALL packages? " -n 1 -r
 echo    # move cursor to a new line

--- a/scripts/curlinstall.sh
+++ b/scripts/curlinstall.sh
@@ -15,7 +15,63 @@
 #   under the GPL along with build & install instructions.
 #
 #################################################################################
-
+echo " --------------------------------------------------------------------- ";
+echo " [ ! ]          C A U T I O N!           !C U I D A D O!          [ ! ]";
+echo " --------------------------------------------------------------------- ";
+echo "";
+echo "THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED"
+echo "WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES"
+echo "OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED."
+echo "IN NO EVENT SHALL THE PROJECT MAINTAINERS OR PROJECT CONTRIBUTORS BE"
+echo "LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,"
+echo "OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF"
+echo "SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS"
+echo "INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN"
+echo "CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)"
+echo "ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF"
+echo "ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. "
+echo "";
+echo "";
+echo " Installation of this software is subject to your acceptance of"
+echo "  these terms."
+echo "";
+read -p "Do you accept these terms? (Y/n)" -n 1 -r
+echo    # move cursor to a new line
+echo ""
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo "ABORTING due to user input. The above terms must be accepted in"
+    echo "order to proceed with the installation. Now exiting."
+    echo "";
+    exit 1;
+else
+    echo "";# leave if statement and continue.
+fi
+echo "";
+echo "";
+echo "This script is about to *UPDATE* AND *UPGRADE* your OS. It is highly "
+echo "  recommended that you deploy this on a new server, and not an existing"
+echo "  one you may already be using. Running upgrades on an existing"
+echo "  in-production server may break your environment and pre-existing setup"
+echo "  of software, programs, scripts, applications, etc."
+echo "";
+echo "";
+#  apt-get upate -y # retrive list of available updates
+#  apt-get upgrade -y" # upgrade out-of-date packages
+#  apt-get fullupgrade -y " # upgrade the OS to latest MAJOR version. ie 12.04 to 18.04. Potentially DANGEROUS for those who may understand what it implies.
+# read: safe shell input check. non-negated answer continues, else aborts.
+read -p "Would you like to proceed updating and upgrading your OS and ALL packages? " -n 1 -r
+echo    # move cursor to a new line
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo "";
+    echo "";
+    echo "ABORTING per user request.";
+    exit 1;
+else
+    echo "";# leave if statement and continue.
+fi
 sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get full-upgrade -y
 sudo apt-get install git -y && sudo apt-get install whiptail -y && sudo apt-get install dialog -y
 sudo rm -r /opt/plexguide
@@ -23,4 +79,4 @@ sudo git clone https://github.com/Admin9705/PlexGuide.com-The-Awesome-Plex-Serve
 sudo bash /opt/plexg*/sc*/ins*
 clear
 echo "To deploy this Script anytime, type: plexguide"
-echo ""
+echo "";


### PR DESCRIPTION
In an effort to offer further transparency for the users of understanding the underlying requirements in this script, this changes the curlinstall.sh script to require the user to understand the risks and responsibilities of running the installer. Users must explicitly manifest their acknowledgement that their OS and or any packages with available updates in configured repositories may be updated and or upgraded. Any other input causes abort of the install script.