### PR TITLE
Add wget unzip to pre-install; speed up and minify

### DIFF
--- a/scripts/curlinstall.sh
+++ b/scripts/curlinstall.sh
@@ -73,7 +73,7 @@ else
     echo "";# leave if statement and continue.
 fi
 sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get full-upgrade -y
-sudo apt-get install git -y && sudo apt-get install whiptail -y && sudo apt-get install dialog -y
+sudo apt-get install dialog git unzip wget whiptail -y
 sudo rm -r /opt/plexguide
 sudo git clone https://github.com/Admin9705/PlexGuide.com-The-Awesome-Plex-Server.git /opt/plexguide
 sudo bash /opt/plexg*/sc*/ins*


### PR DESCRIPTION
Add wget and unzip to pre-install commands. Minify the installation of the packages to be installed in the same round. Won’t suppress errors as they’ll still be seen in line if there are any. Solidifies proposed minified installation method contributed at https://plexguide.com/threads/contribution-minified-install-command.1099/#post-6187

Signed-off-by: YipYup