### PR TITLE
standardize folders used by ubooquity to match Mylar/lazy

### DIFF
--- a/ansible/roles/ubooquity/tasks/main.yml
+++ b/ansible/roles/ubooquity/tasks/main.yml
@@ -44,9 +44,9 @@
           - ubooquity
     volumes:
     - /opt/appdata/ubooquity:/config
-    - /mnt/unionfs/plexguide/ubooquity/books:/books
-    - /mnt/unionfs/plexguide/ubooquity/comics:/comics
-    - /mnt/unionfs/plexguide/ubooquity/raw:/files
+    - /mnt/unionfs/books:/books
+    - /mnt/unionfs/comics:/comics
+    - /mnt/unionfs/raw:/files
     - /etc/localtime:/etc/localtime:ro
     restart_policy: always
     state: started


### PR DESCRIPTION
The folders used in the current ubooquity ansible configuration do not conform to the conventions used by other applications such as Mylar/LazyLibrarian.