### PR TITLE
this should not use the interpolated path

### DIFF
--- a/ansible/roles/rutorrent/tasks/main.yml
+++ b/ansible/roles/rutorrent/tasks/main.yml
@@ -93,7 +93,7 @@
   lineinfile:
     path: "/opt/appdata/rutorrent/rtorrent/rtorrent.rc"
     regexp: '^directory\s?='
-    line: 'directory = /{{path.stdout}}/rutorrent'
+    line: 'directory = /downloads/incoming'
     state: present
   when: rtorrent_rc.stat.exists == False
 


### PR DESCRIPTION
the config directory should refer to a path on the docker container itself