### PR TITLE
check traefik ACME file exists

### DIFF
--- a/roles/traefikdeploy/tasks/main.yml
+++ b/roles/traefikdeploy/tasks/main.yml
@@ -216,6 +216,11 @@
     owner: 1000
     group: 1000
 
+- name: Check acme.json exists
+  stat:
+    path: "/opt/appdata/traefik/acme/acme.json"
+  register: acme_json
+
 - name: Installing ACME
   template:
     src: acme.json
@@ -224,6 +229,7 @@
     mode: 0600
     owner: 1000
     group: 1000
+  when: acme_json.stat.exists == False
 ######################################################### REPLACE STANDARD VARIBLES
 - debug: msg="Provider Info {{providerfinal}}"
 


### PR DESCRIPTION
there should be no reason to make a new every time you deploy traefik. Let's Encrypt have like a 20 certificates per week, per mail limit, so if you have problems and made 20 you're not getting SSL on your things for a week.
https://letsencrypt.org/docs/rate-limits/