### PR TITLE
gdriveclean.sh + move.sh changes

### DIFF
--- a/roles/clean/templates/gdriveclean.js2
+++ b/roles/clean/templates/gdriveclean.js2
@@ -5,11 +5,14 @@ find /mnt/move/.unionfs-fuse -type f -name '*_HIDDEN~' | while read line; do
 oldPath=${line#/mnt/move/.unionfs-fuse}
 newPath=gdrive:${oldPath%_HIDDEN~}
 newPathT=tdrive:${oldPath%_HIDDEN~}
+newPathEn=gcrypt:${oldPath%_HIDDEN~}
 echo "$newPath"
 echo "$newPathT"
+echo "$newPathEn"
 echo "$line"
 /usr/bin/rclone delete "$newPath"
-/usr/bin/rclone delete "$newPathT" 
+/usr/bin/rclone delete "$newPathT"
+/usr/bin/rclone delete "$newPathEn"
 rm "$line"
 done
 find "/mnt/move/.unionfs-fuse" -mindepth 1 -type d -empty -delete

--- a/roles/rclone_en/templates/move_script.js2
+++ b/roles/rclone_en/templates/move_script.js2
@@ -8,7 +8,7 @@ sleep 30
 while true
 do
 ## Sync, Sleep 8 Minutes, Repeat. BWLIMIT Prevents Google 750GB Google Upload Ban
-rclone move --bwlimit 10M --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --max-size 99G --log-file=/opt/appdata/plexguide/rclone --log-level INFO --stats 5s /mnt/move gcrypt:/
+rclone move --bwlimit 10M --tpslimit 6 --min-age 2m -- --exclude='**partial~' --exclude=".grab/**" --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --max-size 99G --log-file=/opt/appdata/plexguide/rclone --log-level INFO --stats 5s /mnt/move gcrypt:/
 sleep 480
 # Remove empty directories (MrWednesday)
 find "/mnt/move/" -mindepth 2 -type d -empty -delete

--- a/roles/rclone_un/templates/move_script.js2
+++ b/roles/rclone_un/templates/move_script.js2
@@ -8,7 +8,7 @@ sleep 30
 while true
 do
 ## Sync, Sleep 8 Minutes, Repeat. BWLIMIT Prevents Google 750GB Google Upload Ban
-rclone move --bwlimit 10M --tpslimit 6 --exclude='**partial~' --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --max-size 99G --log-level INFO --stats 5s /mnt/move gdrive:/
+rclone move --bwlimit 10M --tpslimit 6 --min-age 2m -- --exclude='**partial~' --exclude=".grab/**" --exclude="**_HIDDEN~" --exclude=".unionfs/**" --exclude=".unionfs-fuse/**" --checkers=16 --max-size 99G --log-level INFO --stats 5s /mnt/move gdrive:/
 sleep 480
 # Remove empty directories (MrWednesday)
 find "/mnt/move/" -mindepth 2 -type d -empty -delete


### PR DESCRIPTION
gdriveclean.sh
Edited to also include the gcrypt: rclone location. This will allow the script to cleanup encrypted files.

move.sh
Edited to include --min-age 2m which will ignore any files younger then 2 minutes, useful to not upload files that are mid way through being processed/moved/converted.
Also edited to ignore the folder ".grab", when using plexdvr any recordings are temporarily stored in the .grab folder while ongoing, which should not be uploaded.