### PR TITLE
Fix TLD Role for Tautulli

### DIFF
--- a/roles/organizr/tasks/main.yml
+++ b/roles/organizr/tasks/main.yml
@@ -20,7 +20,10 @@
 
 - include_role:
     name: pgmstart
-
+    
+- include_role:
+    name: tld
+    
 - name: Deploy Organizr Container
   docker_container:
     name: "{{role_name}}"

--- a/roles/organizrv2/tasks/main.yml
+++ b/roles/organizrv2/tasks/main.yml
@@ -20,10 +20,10 @@
 
 - include_role:
     name: pgmstart
-    
+
 - include_role:
     name: tld
-    
+
 - name: Deploy OrganizrV2 Container
   docker_container:
     name: "{{role_name}}"

--- a/roles/organizrv2/tasks/main.yml
+++ b/roles/organizrv2/tasks/main.yml
@@ -20,7 +20,10 @@
 
 - include_role:
     name: pgmstart
-
+    
+- include_role:
+    name: tld
+    
 - name: Deploy OrganizrV2 Container
   docker_container:
     name: "{{role_name}}"

--- a/roles/tautulli/tasks/main.yml
+++ b/roles/tautulli/tasks/main.yml
@@ -20,6 +20,9 @@
 
 - include_role:
     name: pgmstart
+    
+- include_role:
+    name: tld
 
 - name: "Create {{role_name}} script directories"
   file: "path={{item}} state=directory mode=0775 owner=1000 group=1000 recurse=yes"


### PR DESCRIPTION
Previously was missing "include_role: name: tld", a crucial role which prevents it from being properly set to the top level domain. 

Issue Tracking: #371