### PR TITLE
Update traefik image version

### DIFF
--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -281,7 +281,7 @@
 - name: Deploy Traefik Container - CloudFlare
   docker_container:
     name: traefik
-    image: "traefik:1.6"
+    image: "traefik:latest"
     pull: yes
     cpu_shares: 256
     published_ports:


### PR DESCRIPTION
Use the latest version of traefik instead of sticking on 1.6. We should keep up on versions so changes are incremental instead of needing a new config next time we update this :D