### PR TITLE
Ubooquity fix

### DIFF
--- a/roles/ubooquity/tasks/main.yml
+++ b/roles/ubooquity/tasks/main.yml
@@ -46,8 +46,15 @@
     labels:
       traefik.enable: "true"
       traefik.frontend.redirect.entryPoint: "https"
-      traefik.frontend.rule: "Host:{{role_name}}.{{domain.stdout}}"
-      traefik.port: "{{intport}}"
+      traefik.app.frontend.rule: "Host:{{role_name}}.{{domain.stdout}}"
+      traefik.app.port: "{{intport}}"
+      traefik.admin.frontend.rule: "Host:{{role_name}}.{{domain.stdout}};PathPrefix:/admin"
+      traefik.admin.port: "2203"
+
+- name: Remove Proxy Prefix
+  replace:
+    path: "/opt/appdata/{{role_name}}/preferences.json"
+    regexp: "ubooquity"
 
 - include_role:
     name: pgmend


### PR DESCRIPTION
Removed Proxy Prefix from the preferences.json, app now serves at ubooquity.domain.tld and admin at ubooquity.domain.tld/admin. This should resolve #408.