### PR TITLE
Auto-extract zip and rar files from Deluge

### DIFF
--- a/roles/deluge/scripts/extract.sh
+++ b/roles/deluge/scripts/extract.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+formats=(zip rar)
+commands=([zip]="unzip -u" [rar]="unrar -r -o- e")
+extraction_subdir='deluge_extracted'
+
+torrentid=$1
+torrentname=$2
+torrentpath=$3
+
+log()
+{
+    logger -t deluge-extractarchives "$@"
+}
+
+log "Torrent complete: $@"
+cd "${torrentpath}"
+for format in "${formats[@]}"; do
+    while read file; do
+        log "Extracting \"$file\""
+        cd "$(dirname "$file")"
+        file=$(basename "$file")
+        # if extraction_subdir is not empty, extract to subdirectory
+        if [[ ! -z "$extraction_subdir" ]] ; then
+            mkdir "$extraction_subdir"
+            cd "$extraction_subdir"
+            file="../$file"
+        fi
+        ${commands[$format]} "$file"
+    done < <(find "$torrentpath/$torrentname" -iname "*.${format}" )
+done

--- a/roles/deluge/tasks/main.yml
+++ b/roles/deluge/tasks/main.yml
@@ -31,6 +31,36 @@
   with_items:
     - /opt/appdata/{{role_name}}
 
+- name:Create deluge configuration files
+  template:
+    src: "templates/{{item}}.j2"
+    dest: "/opt/appdata/{{role_name}}/{{item}}"
+    owner: 1000
+    group: 1000
+    mode: 0755
+    force: no
+  with_items:
+    - core.conf
+    - execute.conf
+    - autoremoveplus.conf
+
+- name: Create scripts directory with appropriate permissions
+  file:
+    path: "/opt/appdata/{{role_name}}/scripts"
+    state: directory
+    owner: 1000
+    group: 1000
+    mode: 0755
+
+- name: Copy scripts into directory
+  copy:
+    src: scripts
+    dest: "/opt/appdata/{{role_name}}"
+    directory_mode: yes
+    owner: 1000
+    group: 1000
+    mode: 0755
+
 - name: Deploy {{role_name}} Container
   docker_container:
     name: "{{role_name}}"

--- a/roles/deluge/tasks/main.yml
+++ b/roles/deluge/tasks/main.yml
@@ -31,7 +31,7 @@
   with_items:
     - /opt/appdata/{{role_name}}
 
-- name:Create deluge configuration files
+- name: Create deluge configuration files
   template:
     src: "templates/{{item}}.j2"
     dest: "/opt/appdata/{{role_name}}/{{item}}"

--- a/roles/deluge/templates/autoremoveplus.conf.j2
+++ b/roles/deluge/templates/autoremoveplus.conf.j2
@@ -1,0 +1,23 @@
+{
+  "file": 1,
+  "format": 1
+}{
+  "interval": 1.0,
+  "max_seeds": 0, 
+  "sel_func": "or", 
+  "trackers": [], 
+  "remove_data": true, 
+  "labels": [], 
+  "enabled": true, 
+  "count_exempt": false, 
+  "remove": true, 
+  "filter": "func_ratio", 
+  "tracker_rules": {}, 
+  "min": 1.5, 
+  "hdd_space": -1.0, 
+  "filter2": "func_seed_time", 
+  "rule_2_enabled": true, 
+  "min2": 15.0, 
+  "rule_1_enabled": true, 
+  "label_rules": {}
+}

--- a/roles/deluge/templates/core.conf.j2
+++ b/roles/deluge/templates/core.conf.j2
@@ -1,0 +1,104 @@
+{
+  "file": 1, 
+  "format": 1
+}{
+  "info_sent": 0.0, 
+  "lsd": false, 
+  "send_info": false, 
+  "move_completed_path": "{{ downloads }}/complete", 
+  "enc_in_policy": 1, 
+  "queue_new_to_top": true, 
+  "ignore_limits_on_local_network": true, 
+  "rate_limit_ip_overhead": false, 
+  "daemon_port": 58846, 
+  "natpmp": true, 
+  "max_active_limit": "{{ max_active_limit }}", 
+  "utpex": false, 
+  "max_active_downloading": 5, 
+  "max_active_seeding": 10, 
+  "allow_remote": true, 
+  "max_half_open_connections": 50, 
+  "download_location": "{{ downloads }}/incomplete", 
+  "compact_allocation": false, 
+  "max_upload_speed": -1.0, 
+  "cache_expiry": 60, 
+  "prioritize_first_last_pieces": false, 
+  "auto_managed": true, 
+  "enc_level": 2, 
+  "max_connections_per_second": 20, 
+  "dont_count_slow_torrents": true, 
+  "random_outgoing_ports": true, 
+  "max_upload_slots_per_torrent": -1, 
+  "new_release_check": false, 
+  "enc_out_policy": 1, 
+  "outgoing_ports": [
+    0, 
+    0
+  ], 
+  "seed_time_limit": 180, 
+  "cache_size": 512, 
+  "share_ratio_limit": 2.0, 
+  "max_download_speed": -1.0, 
+  "geoip_db_location": "/usr/share/GeoIP/GeoIP.dat", 
+  "torrentfiles_location": "/data/torrents", 
+  "stop_seed_at_ratio": false, 
+  "peer_tos": "0x00", 
+  "listen_interface": "0.0.0.0", 
+  "upnp": true, 
+  "max_download_speed_per_torrent": -1, 
+  "max_upload_slots_global": 4, 
+  "enabled_plugins": [
+    "Label", 
+    "Execute"
+  ], 
+  "random_port": false, 
+  "autoadd_enable": false, 
+  "max_connections_global": 200, 
+  "enc_prefer_rc4": true, 
+  "listen_ports": [
+    58946, 
+    58946
+  ], 
+  "dht": false, 
+  "stop_seed_ratio": 1.5, 
+  "seed_time_ratio_limit": 7.0, 
+  "max_upload_speed_per_torrent": -1, 
+  "copy_torrent_file": false, 
+  "del_copy_torrent_file": false, 
+  "move_completed": true, 
+  "proxies": {
+    "peer": {
+      "username": "", 
+      "password": "", 
+      "type": 0, 
+      "hostname": "", 
+      "port": 8080
+    }, 
+    "web_seed": {
+      "username": "", 
+      "password": "", 
+      "type": 0, 
+      "hostname": "", 
+      "port": 8080
+    }, 
+    "tracker": {
+      "username": "", 
+      "password": "", 
+      "type": 0, 
+      "hostname": "", 
+      "port": 8080
+    }, 
+    "dht": {
+      "username": "", 
+      "password": "", 
+      "type": 0, 
+      "hostname": "", 
+      "port": 8080
+    }
+  }, 
+  "add_paused": false, 
+  "max_connections_per_torrent": -1, 
+  "remove_seed_at_ratio": true, 
+  "autoadd_location": "/data/watched", 
+  "plugins_location": "/config/plugins"
+} 

--- a/roles/deluge/templates/execute.conf.j2
+++ b/roles/deluge/templates/execute.conf.j2
@@ -1,0 +1,12 @@
+{
+  "file": 1, 
+  "format": 1
+}{
+  "commands": [
+    [
+      "0", 
+      "complete", 
+      "/config/scripts/extract.sh"
+    ]
+  ]
+}

--- a/roles/deluge/vars/variables.yml
+++ b/roles/deluge/vars/variables.yml
@@ -18,4 +18,6 @@
 ---
 intport: "8112"
 extport: "8112"
+downloads: "/unionfs/downloaded"
+max_active_limit: "8"
 pgrole: "deluge"

--- a/roles/radarr/scripts/cleanup.sh
+++ b/roles/radarr/scripts/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ -d "$radarr_moviefile_sourcefolder" ] && [ "$(basename $radarr_moviefile_sourcefolder)" = "deluge_extracted" ] ; then
+	/bin/rm -rf $radarr_moviefile_sourcefolder
+fi 

--- a/roles/radarr/tasks/main.yml
+++ b/roles/radarr/tasks/main.yml
@@ -52,6 +52,23 @@
     - /opt/appdata/{{role_name}}/mp4_automator
   when: result.user_input == "3"
 
+- name: Create scripts directory with appropriate permissions
+  file:
+    path: "/opt/appdata/{{role_name}}/scripts"
+    state: directory
+    owner: 1000
+    group: 1000
+    mode: 0755
+
+- name: Copy scripts into directory
+  copy:
+    src: scripts
+    dest: "/opt/appdata/{{role_name}}"
+    directory_mode: yes
+    owner: 1000
+    group: 1000
+    mode: 0755
+
 - name: Deploy {{role_name}} Container
   docker_container:
     name: "{{role_name}}"

--- a/roles/sonarr/scripts/cleanup.sh
+++ b/roles/sonarr/scripts/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ -d "$sonarr_episodefile_sourcefolder" ] && [ "$(basename $sonarr_episodefile_sourcefolder)" = "deluge_extracted" ] ; then
+	/bin/rm -rf $sonarr_episodefile_sourcefolder
+fi 

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -52,6 +52,23 @@
     - /opt/appdata/{{role_name}}/mp4_automator
   when: result.user_input == "3"
 
+- name: Create scripts directory with appropriate permissions
+  file:
+    path: "/opt/appdata/{{role_name}}/scripts"
+    state: directory
+    owner: 1000
+    group: 1000
+    mode: 0755
+
+- name: Copy scripts into directory
+  copy:
+    src: scripts
+    dest: "/opt/appdata/{{role_name}}"
+    directory_mode: yes
+    owner: 1000
+    group: 1000
+    mode: 0755
+
 - name: Deploy {{role_name}} Container
   docker_container:
     name: "{{role_name}}"


### PR DESCRIPTION
Adds a script for Deluge that can autoextract rar and zip files. Must enable 'Execute' plugin and give it the script in '/config/scripts/extract.sh'.

Also adds cleanup scripts for Radarr and Sonarr that will autodelete extracted files generated by extract.sh.

Custom Connection with the scripts at '/config/scripts/cleanup.sh'.