### PR TITLE
Update extraction script copying to new YAML format

### DIFF
--- a/roles/deluge/scripts/extract.sh
+++ b/roles/deluge/scripts/extract.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copied from https://github.com/Radarr/Radarr/wiki/Common-Problems on August 19, 2018
+# the Radarr script was originally sourced from https://dev.deluge-torrent.org/wiki/Plugins/Execute
+
 formats=(zip rar)
 commands=([zip]="unzip -u" [rar]="unrar -r -o- e")
 extraction_subdir='deluge_extracted'

--- a/roles/deluge/tasks/core.yml
+++ b/roles/deluge/tasks/core.yml
@@ -39,6 +39,23 @@
     - "{{path.stdout}}/{{role_name}}"
     - "/opt/appdata/{{role_name}}"
 ############################################################# (BASICS END)
+- name: "Create scripts folder - {{pgrole}}"
+  file:
+    path: /opt/appdata/{{role_name}}/scripts
+    state: directory
+    owner: 1000
+    group: 1000
+    mode: 0755
+
+- name: "Copy scripts into directory - {{pgrole}}"
+  copy:
+    src: scripts
+    dest: /opt/appdata/{{role_name}}
+    directory_mode: yes
+    owner: 1000
+    group: 1000
+    mode: 0755
+
 - name: "Set Default Volume - {{pgrole}}"
   set_fact:
     default_volumes:

--- a/roles/radarr/scripts/cleanup.sh
+++ b/roles/radarr/scripts/cleanup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Copied from https://github.com/Radarr/Radarr/wiki/Common-Problems on August 19, 2018
+
 if [ -d "$radarr_moviefile_sourcefolder" ] && [ "$(basename $radarr_moviefile_sourcefolder)" = "deluge_extracted" ] ; then
 	/bin/rm -rf $radarr_moviefile_sourcefolder
 fi 

--- a/roles/radarr/tasks/core.yml
+++ b/roles/radarr/tasks/core.yml
@@ -57,6 +57,23 @@
 ############################################################# (BASICS START)
 #
 ############################################################# (BASICS END)
+- name: "Create scripts folder - {{pgrole}}"
+  file:
+    path: /opt/appdata/{{role_name}}/scripts
+    state: directory
+    owner: 1000
+    group: 1000
+    mode: 0755
+
+- name: "Copy scripts into directory - {{pgrole}}"
+  copy:
+    src: scripts
+    dest: /opt/appdata/{{role_name}}
+    directory_mode: yes
+    owner: 1000
+    group: 1000
+    mode: 0755
+    
 - name: "Set Default Volume - {{pgrole}}"
   set_fact:
     default_volumes:

--- a/roles/sonarr/scripts/cleanup.sh
+++ b/roles/sonarr/scripts/cleanup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copied from https://github.com/Radarr/Radarr/wiki/Common-Problems on August 19, 2018
+# Modified for Sonarr variables instead of Radarr variables
+
 if [ -d "$sonarr_episodefile_sourcefolder" ] && [ "$(basename $sonarr_episodefile_sourcefolder)" = "deluge_extracted" ] ; then
 	/bin/rm -rf $sonarr_episodefile_sourcefolder
 fi 

--- a/roles/sonarr/tasks/core.yml
+++ b/roles/sonarr/tasks/core.yml
@@ -57,6 +57,23 @@
 ############################################################# (BASICS START)
 #
 ############################################################# (BASICS END)
+- name: "Create scripts folder - {{pgrole}}"
+  file:
+    path: /opt/appdata/{{role_name}}/scripts
+    state: directory
+    owner: 1000
+    group: 1000
+    mode: 0755
+
+- name: "Copy scripts into directory - {{pgrole}}"
+  copy:
+    src: scripts
+    dest: /opt/appdata/{{role_name}}
+    directory_mode: yes
+    owner: 1000
+    group: 1000
+    mode: 0755
+    
 - name: "Set Default Volume - {{pgrole}}"
   set_fact:
     default_volumes:


### PR DESCRIPTION
YAML update did not include anything that copies extract and cleanup scripts into the correct location, this pull request fixes that.

Also, added some comments to scripts to make it more clear where the scripts came from (I did not write them).