### PR TITLE
added metric endpoint for prometheus port 8081 as not exposed port

### DIFF
--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -125,6 +125,7 @@
       PLEX_GID: "1000"
       PLEX_CLAIM: "{{ptoken}}"
       ADVERTISE_IP: "{{customConnections}}"
+    purge_networks: yes
     networks:
       - name: plexguide
         aliases:

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -300,6 +300,7 @@
       - /opt/appdata/traefik/traefik.toml:/etc/traefik/traefik.toml:ro
       - /opt/appdata/traefik/servers.toml:/etc/traefik/servers.toml:ro
       - /opt/appdata/traefik/acme:/etc/traefik/acme
+    purge_networks: yes
     networks:
       - name: plexguide
         aliases:

--- a/roles/traefik/templates/traefik.toml
+++ b/roles/traefik/templates/traefik.toml
@@ -42,6 +42,8 @@ defaultEntryPoints = ["http", "https"]
   [entryPoints.https]
   address = ":443"
     [entryPoints.https.tls]
+  [entryPoints.monitor]
+  address = "8081"
 
 [retry]
 
@@ -64,3 +66,8 @@ endpoint = "unix:///var/run/docker.sock"
 domain = "yourdomain.com"
 watch = true
 exposedbydefault = false
+
+[metrics]
+  [metrics.prometheus]
+  entryPoint = "monitor"
+  buckets = [0.1,0.3,1.2,5.0]


### PR DESCRIPTION
Lets you monitor traffic with prometheus, as port is not exposed it will not make a security risk, but lets you monitor traefik from the internet network.

Also removes all network expect for plexguide from Traefik and plex