### PR TITLE
Add plexguide as default docker network

### DIFF
--- a/roles/traefik/templates/traefik.toml
+++ b/roles/traefik/templates/traefik.toml
@@ -66,3 +66,4 @@ endpoint = "unix:///var/run/docker.sock"
 domain = "yourdomain.com"
 watch = true
 exposedbydefault = false
+network = "plexguide"


### PR DESCRIPTION
So I was having some trouble accessing most containers via Traefik on a clean install. After every rebuild, a different batch of containers would become inaccessible.

Looking at Traefik's docs, I found this interesting footnote:
> `traefik.docker.network`: If a container is linked to several networks, be sure to set the proper network name otherwise it will randomly pick one (depending on how docker is returning them)...

Adding a default network to `traefik.toml` solved the problem.