### PR TITLE
fix missing "Host:" in traefik rule

### DIFF
--- a/roles/pgmstart/tasks/keyvar.yml
+++ b/roles/pgmstart/tasks/keyvar.yml
@@ -92,4 +92,4 @@
       traefik.enable: "true"
       traefik.port: "{{intport}}"
       traefik.frontend.redirect.entryPoint: "https"
-      traefik.frontend.rule: "{{pgrole}}.{{domain.stdout}},{{tldset}}"
+      traefik.frontend.rule: "Host:{{pgrole}}.{{domain.stdout}},{{tldset}}"


### PR DESCRIPTION
broke some stuff and gave "404 page not found" error