### PR TITLE
Update jackett.yml

### DIFF
--- a/programs/containers/jackett.yml
+++ b/programs/containers/jackett.yml
@@ -34,7 +34,7 @@
 - name: "Set Default Volume - {{pgrole}}"
   set_fact:
     default_volumes:
-      - "/opt/appdata/{{role_name}}:/config"
+      - "/opt/appdata/{{pgrole}}:/config"
       - "/mnt/unionfs:/unionfs"
       - "{{path.stdout}}/deluge/temp:/temp"
       - "{{path.stdout}}/deluge/downloaded:/downloaded"


### PR DESCRIPTION
Fixed undefined variable usage, causing the installation of Jackett to crash.