### PR TITLE
disable port 80, Force min secure SSL version, disable insecure ciphers

### DIFF
--- a/roles/traefik/templates/traefik.toml
+++ b/roles/traefik/templates/traefik.toml
@@ -32,16 +32,14 @@ insecureskipverify = true
 
 logLevel = "WARN"
 
-defaultEntryPoints = ["http", "https"]
+defaultEntryPoints = ["https"]
 
 [entryPoints]
-  [entryPoints.http]
-  address = ":80"
-  #[entryPoints.http.redirect]
-  #  entryPoint = "https"
   [entryPoints.https]
   address = ":443"
     [entryPoints.https.tls]
+    MinVersion = "VersionTLS12"
+    CipherSuites = ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256","TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"]
   [entryPoints.monitor]
   address = ":8081"
 


### PR DESCRIPTION
I checked a few apps and none of them use a http front end for traefik. You are also not redirecting port 80. So unless I'm mistaken, there's no reason to be listening on port 80 since everything that is exposed is https anyway. So I'm disabling it.

I'm also forcing TLS1.2 or newer, anything else is insecure. I'm also disabling all the insecure ciphers and only enabling modern good ones.

https://wiki.mozilla.org/Security/Server_Side_TLS#Cipher_names_correspondence_table

