### PR TITLE
Removed 'LC_ALL: "C"' variable

### DIFF
--- a/programs/containers/sabnzbd.yml
+++ b/programs/containers/sabnzbd.yml
@@ -48,4 +48,4 @@
     default_env:
       PUID: 1000
       PGID: 1000
-      LC_ALL: "C"
+   


### PR DESCRIPTION
The LC_ALL: "C" environment variable causes SABnzbd to complain about not running within an UTF-8 language space. It is not needed according to the person maintaining the linuxserver.io container.