### PR TITLE
fix: qbittorrent port conflict with sabnzbd

### DIFF
--- a/programs/containers/qbittorrent.yml
+++ b/programs/containers/qbittorrent.yml
@@ -18,7 +18,7 @@
 - name: "Container Variables"
   set_fact:
     intport: "8080"
-    extport: "8080"
+    extport: "8081"
     image: "linuxserver/qbittorrent"
     cpu_shares: 128
     expose: ""


### PR DESCRIPTION
@Admin9705  currently qbittorrent will fail to install if you previously installed sabnzbd and vise-versa