### PR TITLE
fix: qittorrent ext port

### DIFF
--- a/programs/containers/qbittorrent.yml
+++ b/programs/containers/qbittorrent.yml
@@ -18,7 +18,7 @@
 - name: "Container Variables"
   set_fact:
     intport: "8080"
-    extport: "8080"
+    extport: "8081"
     image: "linuxserver/qbittorrent"
     cpu_shares: 128
     expose: ""


### PR DESCRIPTION
qbittorrent will fail to install if sab is installed.
```TASK [Deploy qbittorrent Container] ************************************************************************
Wednesday 17 October 2018  03:06:26 -0700 (0:00:00.053)       0:00:07.344 ***** 
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Error starting container 61a26159fb5bf2cfb7bffbb2596e84881ead58bcf4616078389ffcf3f1052ec5: 500 Server Error: Internal Server Error (\"driver failed programming external connectivity on endpoint qbittorrent (1576422007ed3753db1266592403759729cd37e9674aea06304f41412ee35588): Bind for 127.0.0.1:8080 failed: port is already allocated\")"}
        to retry, use: --limit @/opt/plexguide/programs/core/main.retry

PLAY RECAP *************************************************************************************************
127.0.0.1                  : ok=28   changed=10   unreachable=0    failed=1   ```
