### PR TITLE
changing to the new netdata docker

### DIFF
--- a/programs/containers/netdata.yml
+++ b/programs/containers/netdata.yml
@@ -19,7 +19,7 @@
   set_fact:
     intport: "19999"
     extport: "19999"
-    image: "firehol/netdata"
+    image: "netdata/netdata"
     cpu_shares: 128
     expose: ""
 


### PR DESCRIPTION
> As of Sep 18, 2018 netdata has its own organization and everyone is urged to use new conatiner images located at netdata/netdata. We will continue to push images to this repository until 1.12 release, after that point all images will be deleted from this repo.
> 
> Netdata now has its own github organization netdata, so all github URLs are now netdata/netdata. The old github URLs, repo clones, forks, etc redirect automatically to the new repo.