### PR TITLE
Fixes to set pyload configs directory and downloads path

### DIFF
--- a/programs/containers/pyload.yml
+++ b/programs/containers/pyload.yml
@@ -33,10 +33,17 @@
       traefik.frontend.redirect.entryPoint: "https"
       traefik.frontend.rule: "Host:{{pgrole}}.{{domain.stdout}},{{tldset}}"
 
+- name: Create Folders
+  file: "path={{item}} state=directory mode=0775 owner=1000 group=1000"
+  with_items:
+    - /opt/appdata/{{pgrole}}
+    - /mnt/{{pgrole}}
+
 - name: "Set Default Volume - {{pgrole}}"
   set_fact:
     default_volumes:
-      - "/opt/appdata/{{pgrole}}:/config"
+      - "/opt/appdata/{{pgrole}}:/opt/pyload/pyload-config"
+      - "/mnt/{{pgrole}}:/opt/pyload/Downloads"
       - "/etc/localtime:/etc/localtime:ro"
 
 - name: "Establish Key Variables"

--- a/programs/containers/pyload.yml
+++ b/programs/containers/pyload.yml
@@ -37,13 +37,13 @@
   file: "path={{item}} state=directory mode=0775 owner=1000 group=1000"
   with_items:
     - /opt/appdata/{{pgrole}}
-    - /mnt/{{pgrole}}
+    - {{path.stdout}}/{{pgrole}}
 
 - name: "Set Default Volume - {{pgrole}}"
   set_fact:
     default_volumes:
       - "/opt/appdata/{{pgrole}}:/opt/pyload/pyload-config"
-      - "/mnt/{{pgrole}}:/opt/pyload/Downloads"
+      - "{{path.stdout}}/{{pgrole}}:/opt/pyload/Downloads"
       - "/etc/localtime:/etc/localtime:ro"
 
 - name: "Establish Key Variables"

--- a/programs/containers/pyload.yml
+++ b/programs/containers/pyload.yml
@@ -2,7 +2,7 @@
 #
 # Version:  Ansible-1
 # GitHub:   https://github.com/Admin9705/PlexGuide.com-The-Awesome-Plex-Server
-# Author:   Admin9705 & Deiteq & Bryde ツ
+# Author:   Admin9705 & Deiteq & Bryde ?
 # URL:      https://plexguide.com
 #
 # PlexGuide Copyright (C) 2018 PlexGuide.com
@@ -36,8 +36,8 @@
 - name: Create Folders
   file: "path={{item}} state=directory mode=0775 owner=1000 group=1000"
   with_items:
-    - /opt/appdata/{{pgrole}}
-    - {{path.stdout}}/{{pgrole}}
+    - "/opt/appdata/{{pgrole}}"
+    - "{{path.stdout}}/{{pgrole}}"
 
 - name: "Set Default Volume - {{pgrole}}"
   set_fact:


### PR DESCRIPTION
The pyload configs will be generated on run in /opt/appdata/pyload and the downloads path is set to {{path.stdout}}/{{pgrole}} which a few people have said would be their preferred storage area (aka outside gdrive/move)
Ideally it would ask the user but I have not worked with questions much yet in ansible, this should get pyload working for users though.
If they change the pyload default username and password via the web interface restarting the container will revert back to the defaults as the only way to save the changes are via the command line running the script they mention in the change password page.

Hopefully this is fine but testing on my vm has not had any issues when using the Base plugin (aka not a download site, a direct file download)

I intend to use Pyload but given people are asking for a fix I thought this might help until they crowdsource any more quirks or bugs.