### PR TITLE
add /yourcomputer to emby

### DIFF
--- a/programs/containers/emby.yml
+++ b/programs/containers/emby.yml
@@ -40,6 +40,7 @@
       - /mnt/plexdrive/:/plexdrive
       - /mnt/unionfs:/unionfs
       - /mnt/encrypt:/encrypt
+      - /:/yourcomputer
 
 - name: "Establish Key Variables"
   set_fact:


### PR DESCRIPTION
adds the same path to emby, I tested an dev install and it had access although I personally dont use emby to test fully.