### PR TITLE
Fix some typos and some suggestions

### DIFF
--- a/menu/hetzner/hetzner.sh
+++ b/menu/hetzner/hetzner.sh
@@ -19,14 +19,14 @@ if [ "$test" == "" ]; then
 tee <<-EOF
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-⛔️  WARNING! - You Must Input an API from Hetzner First!
+⛔️  WARNING! - You Must Input an API Token from Hetzner First!
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ⚡ Reference: http://hcloud.plexguide.com
 
 * Activate a Hetzner Cloud Account and Create a Project
 * Click Access (left hand side) and then click API Tokens
 * Create a Token and Save It (and paste below here)
-* Not Ready? Just Something & Press [ENTER]
+* Not Ready? Just type something & Press [ENTER]
 
 EOF
 hcloud context create plexguide


### PR DESCRIPTION
Hello @Admin9705,

first of all, thank you for your integration of the Hetzner Cloud! I have found some little typos, which this pr correct. 

Suggestions:

I saw you hard coded the "images" list. A better solution would be to call `hcloud image list -t system -o columns=ID,Name,Description`, the output would be:
![bildschirmfoto 2018-11-19 um 06 55 11](https://user-images.githubusercontent.com/4281581/48688829-1732ec80-ebc8-11e8-80ab-ceb66ad3f4dc.png)
Why this suggestion?
When we change the available OS, you need to perform an update every time. With this solution, you doesn't need an update :) And if you leave out the `-t system` - Parameter you could allow users to create a server from a snapshot. And you have currently inline to only use Ubuntu 18.04 :)
https://github.com/Admin9705/PlexGuide.com-The-Awesome-Plex-Server/blob/Edge/menu/hetzner/hetzner.sh#L105

You should allow the user to choose the Location/Datacenter to create the server and the type. Currently you have the "cx11" inline. 
https://github.com/Admin9705/PlexGuide.com-The-Awesome-Plex-Server/blob/Edge/menu/hetzner/hetzner.sh#L105

Thanks!