### PR TITLE
Added nocows = 1 to ansible.cfg to prevent cows from showing

### DIFF
--- a/menu/interface/install/scripts/ansible.sh
+++ b/menu/interface/install/scripts/ansible.sh
@@ -46,6 +46,9 @@ if [ "$pg_ansible" == "$pg_ansible_stored" ]; then
       echo "callback_whitelist = profile_tasks" >> /etc/ansible/ansible.cfg
       echo "inventory = /etc/ansible/inventories/local" >> /etc/ansible/ansible.cfg
 
+      ### Disabling cows for people that have cowsay installed
+      echo "nocows = 1" >> /etc/ansible/ansible.cfg
+
       cat /var/plexguide/pg.ansible > /var/plexguide/pg.ansible.stored
   fi
 ######################################################## END: Main Script


### PR DESCRIPTION
When cowsay package is installed in host system, ansible will automatically show cows on every line. This gets annoying very fast; Thankfully, there's a way to fix that 😊