### PR TITLE
Fixing Cloudflare not being updated from Traefik 

### DIFF
--- a/menu/traefik/cloudflare.yml
+++ b/menu/traefik/cloudflare.yml
@@ -40,8 +40,8 @@
         PUID: 1000
         PGID: 1000
         PROVIDER: cloudflare
-        CLOUDFLARE_EMAIL: "{{part1.stdout}}"
-        CLOUDFLARE_API_KEY: "{{part2.stdout}}"
+        CF_API_EMAIL: "{{part1.stdout}}"
+        CF_API_KEY: "{{part2.stdout}}"
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock:ro
         - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
Traefik updated the environment variables in version 1.7, per here: https://docs.traefik.io/configuration/acme/ (v1.6 still shows the old versions: https://docs.traefik.io/v1.6/configuration/acme/)

This fix should now make it possible for Traefik to update DNS into Cloudflare

----

@Admin9705 I think just updated the env variables will be enough, the other references to CLOUDFLARE_EMAIL and CLOUDFLARE_API_KEY appear to be for internal use only?