### PR TITLE
PG Move: wrong permissions

### DIFF
--- a/roles/menu-move/templates/gcrypt.js2
+++ b/roles/menu-move/templates/gcrypt.js2
@@ -21,7 +21,7 @@ After=multi-user.target
 Type=simple
 User=0
 Group=0
-ExecStart=/usr/bin/rclone --allow-non-empty --allow-other mount gcrypt: /mnt/gcrypt
+ExecStart=/usr/bin/rclone --allow-non-empty --allow-other mount gcrypt: /mnt/gcrypt \
                       --uid=1000 --gid=1000 \
                       --size-only --dir-cache-time=2m \
                       --vfs-read-chunk-size=96M --vfs-cache-max-age 675h --vfs-read-chunk-size-limit=1G \


### PR DESCRIPTION
Hey,

due to typo in `roles/menu-move/templates/gcrypt.js2` rclone is mounting drive with wrong permissions. Import function in sonarr and radarr isn't working correctly because of that.