### PR TITLE
Update sonarrbeta.yml

### DIFF
--- a/containers/sonarrbeta.yml
+++ b/containers/sonarrbeta.yml
@@ -40,7 +40,7 @@
         - "/opt/appdata/{{pgrole}}:/config"
         - "/mnt/unionfs:/unionfs"
         - "/mnt/:/mnt"
-        - "{{path.stdout}}/sab/complete:/complete"
+        - "{{path.stdout}}/sab/downloads:/config/Downloads"
         - "{{path.stdout}}/nzbget/downloads/completed/:/completed"
         - "{{path.stdout}}/rutorrent:/downloads"
         - "{{path.stdout}}/deluge/downloaded:/downloaded"


### PR DESCRIPTION
Changed to match new SABNZBD container paths. Matches Sonarr.yml example.