### PR TITLE
Update synclounge.yml

### DIFF
--- a/containers/synclounge.yml
+++ b/containers/synclounge.yml
@@ -49,6 +49,7 @@
       pg_env:
          UID: 1000
          GID: 1000
+         DOMAIN: "{{pgrole}}.{{domain.stdout}}"
 
 # MAIN DEPLOYMENT #############################################################
 


### PR DESCRIPTION
added domain to env, that's used when creating invite links and some other stuff. Right now the invite links are localhost.