### PR TITLE
Allow path separators in download path (eg. /mnt/sdb/plexguide)

### DIFF
--- a/menu/functions/pgblitz.sh
+++ b/menu/functions/pgblitz.sh
@@ -90,7 +90,7 @@ for i in `find $downloadpath/pgblitz/* -maxdepth 1 -mindepth 1 -mmin +30 -type d
         log "Bad Key Count $badcount of 3 Reached! Switching GDSA Keys @ 3!"
         echo $badcount > /var/plexguide/blitz.badkey
       fi
-    mv ${i} /mnt/move
+    mv ${i} "$downloadpath/move"
 done
 
 }

--- a/menu/functions/pgblitz.sh
+++ b/menu/functions/pgblitz.sh
@@ -32,7 +32,7 @@ starter () {
 
 stasks () {
   #copy any files that failed to upload back to /mnt/move
-  for i in `find /mnt/pgblitz/ -maxdepth 1 -mindepth 1 -type d`; do
+  for i in `find $downloadpath/pgblitz/ -maxdepth 1 -mindepth 1 -type d`; do
       cp -r ${i}/* $downloadpath/move
       rm -fr ${i}/*
   done

--- a/menu/pgclone/templates/upload.sh
+++ b/menu/pgclone/templates/upload.sh
@@ -22,9 +22,9 @@ GDSA=$2
 log "[Upload] Upload started for $FILE using $GDSA"
 
 STARTTIME=`date +%s`
-FILESTER=`echo $FILE | sed 's/\'$downloadpath'\/move//g'`
+FILESTER=`echo $FILE | sed 's|\'$downloadpath'\/move||g'`
 FILEBASE=`basename $FILE`
-FILEDIR=`dirname $FILE | sed 's/\'$downloadpath'\/move//g'`
+FILEDIR=`dirname $FILE | sed 's|\'$downloadpath'\/move||g'`
 
 JSONFILE=/opt/appdata/pgblitz/json/$FILEBASE.json
 
@@ -108,7 +108,7 @@ log "[Upload] Upload complete for $FILE, Cleaning up"
 #cleanup
 rm -f $LOGFILE
 rm -f /opt/appdata/pgblitz/pid/$FILEBASE.trans
-find "/mnt/move/" -mindepth 1 -type d -empty -delete
+find "$downloadpath/move/" -mindepth 1 -type d -empty -delete
 find "/mnt/pgblitz/" -mindepth 2 -type d -empty -delete
 sleep 60
 rm -f $JSONFILE


### PR DESCRIPTION
(this time to correct branch)