### PR TITLE
add cleanup scripts for radarr and sonarr

### DIFF
--- a/containers/radarr.yml
+++ b/containers/radarr.yml
@@ -61,6 +61,23 @@
           PGID: 1000
 
     # MAIN DEPLOYMENT #############################################################
+    - name: "Create scripts directory for {{pgrole}}"
+      file:
+        path: /opt/appdata/{{pgrole}}/scripts
+        state: directory
+        owner: 1000
+        group: 1000
+        mode: 0755
+
+    - name: "Copy scripts into directory for {{pgrole}}"
+      copy:
+        src: ./templates/cleanup-radarr.sh
+        dest: /opt/appdata/{{pgrole}}/scripts
+        directory_mode: yes
+        force: yes
+        owner: 1000
+        group: 1000
+        mode: 0755
 
     - name: "Deploying {{pgrole}}"
       docker_container:

--- a/containers/sonarr.yml
+++ b/containers/sonarr.yml
@@ -62,6 +62,23 @@
           PGID: 1000
 
     # MAIN DEPLOYMENT #############################################################
+    - name: "Create scripts directory for {{pgrole}}"
+      file:
+        path: /opt/appdata/{{pgrole}}/scripts
+        state: directory
+        owner: 1000
+        group: 1000
+        mode: 0755
+
+    - name: "Copy scripts into directory for {{pgrole}}"
+      copy:
+        src: ./templates/cleanup-sonarr.sh
+        dest: /opt/appdata/{{pgrole}}/scripts
+        directory_mode: yes
+        force: yes
+        owner: 1000
+        group: 1000
+        mode: 0755
 
     - name: "Deploying {{pgrole}}"
       docker_container:

--- a/containers/templates/cleanup-radarr.sh
+++ b/containers/templates/cleanup-radarr.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ -d "$radarr_moviefile_sourcefolder" ] && [ "$(basename $radarr_moviefile_sourcefolder)" = "deluge_extracted" ] ; then
+    /bin/rm -rf $radarr_moviefile_sourcefolder
+fi

--- a/containers/templates/cleanup-sonarr.sh
+++ b/containers/templates/cleanup-sonarr.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ -d "$sonarr_episodefile_sourcefolder" ] && [ "$(basename $sonarr_episodefile_sourcefolder)" = "deluge_extracted" ] ; then
+    /bin/rm -rf $sonarr_episodefile_sourcefolder
+fi


### PR DESCRIPTION
These scripts haven't been in the correct location for some time. Made changes so that they get copied to the correct location again to work properly with deluge_extract.sh.