### PR TITLE
Update pgblitz.sh

### DIFF
--- a/menu/pgclone/templates/pgblitz.sh
+++ b/menu/pgclone/templates/pgblitz.sh
@@ -37,7 +37,7 @@ while [ 1 ]; do
   keyuse=$(sed -n ''$keycurrent'p' < /opt/appdata/plexguide/key.list)
 
   encheck=$(cat /var/plexguide/pgclone.transport)
-  if [ "$encheck" == "eblitz" ]; then keyuse=${keyuse}C; fi
+  if [ "$encheck" == "eblitz" ]; then keyuse=${keyuse}; fi
 
   rclone moveto --min-age=2m \
         --config /opt/appdata/plexguide/rclone.conf \


### PR DESCRIPTION
"keyuse=${keyuse}C;" results in service pgblitz status returning 
Jan 10 01:55:57 pgvm bash[4828]: Upload Test - Using C 

and blitz to return following error message:
2019/01/10 02:12:49 Failed to create file system for destination "C:/": didn't find section in config file 

which stops pgblitz from further uploading operations.

keyuse=${keyuse}; results in service pgblitz status to return correct service worker keys and correct upload behaviour again.