### PR TITLE
Update deploy to catch if install list is empty

### DIFF
--- a/menu/pgbox/pgboxcommunity.sh
+++ b/menu/pgbox/pgboxcommunity.sh
@@ -137,7 +137,11 @@ $buildup
 EOF
 read -p '🌍 Type APP for QUEUE | Press [ENTER]: ' typed < /dev/tty
 
-if [ "$typed" == "deploy" ]; then question2; fi
+if [ "$typed" == "deploy" ] && [ -z "$p" ]; then
+  echo "ERROR -- No APP Queued for Install!"
+elif [ "$typed" == "deploy" ]; then
+  question2
+fi
 
 if [ "$typed" == "exit" ]; then exit; fi
 

--- a/menu/pgbox/pgboxcore.sh
+++ b/menu/pgbox/pgboxcore.sh
@@ -135,7 +135,11 @@ $buildup
 EOF
 read -p '🌍 Type APP for QUEUE | Press [ENTER]: ' typed < /dev/tty
 
-if [ "$typed" == "deploy" ]; then question2; fi
+if [ "$typed" == "deploy" ] && [ -z "$p" ]; then 
+  echo "ERROR -- No APP Queued for Install!"
+elif [ "$typed" == "deploy" ]; then
+  question2
+fi
 
 if [ "$typed" == "exit" ]; then exit; fi
 


### PR DESCRIPTION
Just a small change to address when a user selects deploy with an empty queue.

The discussion that led to this is here:
https://plexguide.com/threads/first-time-installing-pg.3608
