### PR TITLE
version # in community has a period between "v" and "8" unlike core

### DIFF
--- a/menu/pgbox/pgboxcommunity.yml
+++ b/menu/pgbox/pgboxcommunity.yml
@@ -16,5 +16,5 @@
       git:
         repo: "https://github.com/Admin9705/PlexGuide-Community"
         dest: /opt/communityapps
-        version: "v8.4"
+        version: "v.8.4"
         force: yes


### PR DESCRIPTION
Corrected the version to match the fork title.